### PR TITLE
Grep for exact match on tmux session name

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -225,7 +225,7 @@ if [ "$FILENAME" != "" ]; then
 fi
 
 # Check if tmux-session is available
-if tmux ls 2> /dev/null | grep -q "${TMUX_SESSION_NAME}"; then
+if tmux ls 2> /dev/null | grep -wq "${TMUX_SESSION_NAME}"; then
 	# Setup synchronizing panes
 	synchronizePanes ${SYNCHRONIZE_PANES} ${TMUX_SESSION_NAME}
 


### PR DESCRIPTION
This avoids attaching to existing session that has common string, e.g.:
- Session 1 name: `session`
- Session 2 name: `session_redux`

Without the `-w` option on the grep, the `session_redux` will not be created since script will detect that there is a session already named `session`.